### PR TITLE
Allow endless notifications

### DIFF
--- a/src/components/item.jsx
+++ b/src/components/item.jsx
@@ -11,7 +11,9 @@ export default class Notification extends Component {
       deleteAfter,
     } = props;
 
-    this.deleteTimeout = setTimeout(() => deleteNotification(notificationId), deleteAfter);
+    if (deleteAfter) {
+      this.deleteTimeout = setTimeout(() => deleteNotification(notificationId), deleteAfter);
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
If **deleteAfter** option is set to *0* , then notification won't be closed until user clicks on close btn.