### PR TITLE
Remove redundant property

### DIFF
--- a/src/components/item.jsx
+++ b/src/components/item.jsx
@@ -6,12 +6,11 @@ export default class Notification extends Component {
     super(props);
 
     const {
-      notificationId,
       deleteNotification,
       deleteAfter,
     } = props;
 
-    this.deleteTimeout = setTimeout(() => deleteNotification(notificationId), deleteAfter);
+    this.deleteTimeout = setTimeout(() => deleteNotification(), deleteAfter);
   }
 
   componentWillUnmount() {
@@ -20,7 +19,6 @@ export default class Notification extends Component {
 
   render() {
     const {
-      notificationId,
       notificationMessage,
       deleteNotification,
       classNamePrefix,
@@ -33,7 +31,7 @@ export default class Notification extends Component {
         </div>
         <button
           type="button"
-          onClick={() => deleteNotification(notificationId)}
+          onClick={() => deleteNotification()}
         >
           &times;
         </button>
@@ -43,7 +41,6 @@ export default class Notification extends Component {
 }
 
 Notification.propTypes = {
-  notificationId: PropTypes.string.isRequired,
   notificationMessage: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,

--- a/src/components/provider.jsx
+++ b/src/components/provider.jsx
@@ -89,7 +89,7 @@ export default class NotificationsProvider extends Component {
         notificationId={id}
         notificationMessage={message}
         deleteAfter={deleteAfter}
-        deleteNotification={this.deleteNotification}
+        deleteNotification={nId => this.deleteNotification(nId || id)}
       />
     ));
 


### PR DESCRIPTION
Property *notificationId* is used in **Notification** component for deletion only. So it's logical to move passing of id to provider.

Saved backward compatibility 